### PR TITLE
Problem: Installation instructions out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ cd hyperpad-desktop
 
 $ npm install
 
-$ npm run rebuild-leveldb
+$ npm run rebuild
 
 $ npm run start
 ```


### PR DESCRIPTION
A recent commit changed changed `rebuild-leveldb` to `rebuild`.

Solution: Change instructions in `README.md` from `npm run rebuild-leveldb` to `npm run rebuild`